### PR TITLE
Enable text in images by default

### DIFF
--- a/src/views/UploadToAWSS3.vue
+++ b/src/views/UploadToAWSS3.vue
@@ -637,7 +637,7 @@ export default {
                 labelDetectionImage: {
                   Enabled: this.enabledOperators.includes("labelDetection")
                 },
-                TextDetectionImage: {
+                textDetectionImage: {
                   Enabled: this.enabledOperators.includes("textDetection")
                 },
                 celebrityRecognitionImage: {


### PR DESCRIPTION
*Issue #, if available:*

fix type-o to enable text in images by default

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
