### PR TITLE
Support multiple deploys diff backend

### DIFF
--- a/IMPLEMENTATION_GUIDE.md
+++ b/IMPLEMENTATION_GUIDE.md
@@ -101,7 +101,8 @@ DATETIME=$(date '+%s')
 DIST_OUTPUT_BUCKET=media-insights-engine-$DATETIME
 aws s3 mb s3://$DIST_OUTPUT_BUCKET-$REGION --region $REGION
 ./build-s3-dist.sh $DIST_OUTPUT_BUCKET-$REGION $VERSION $REGION 
-aws cloudformation create-stack --stack-name $MIE_STACK_NAME --template-url https://$DIST_OUTPUT_BUCKET-$REGION.s3.$REGION.amazonaws.com/media-insights-solution/$VERSION/cf/media-insights-stack.template --region $REGION --parameters ParameterKey=DeployOperatorLibrary,ParameterValue=true ParameterKey=DeployTestWorkflow,ParameterValue=true ParameterKey=MaxConcurrentWorkflows,ParameterValue=10 ParameterKey=DeployAnalyticsPipeline,ParameterValue=true --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --profile default --disable-rollback
+TEMPLATE=[copy from the last line output from the build script]
+aws cloudformation create-stack --stack-name $MIE_STACK_NAME --template-url $TEMPLATE --region $REGION --parameters ParameterKey=DeployOperatorLibrary,ParameterValue=true ParameterKey=DeployTestWorkflow,ParameterValue=true ParameterKey=MaxConcurrentWorkflows,ParameterValue=10 ParameterKey=DeployAnalyticsPipeline,ParameterValue=true --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --profile default --disable-rollback
 ```
 
 After the stack finished deploying then you should see the following 6 nested stacks (with slightly different names than shown below):
@@ -135,13 +136,13 @@ aws s3 mb s3://$DIST_OUTPUT_BUCKET-$REGION --region $REGION
 #### *Option 1:* Install front-end only
 ```
 MIE_STACK_NAME=[specify the name of your exising MIE stack]
-TEMPLATE={copy "With existing MIE deployment" link from output of build script}
+TEMPLATE=[copy "With existing MIE deployment" link from output of build script]
 aws cloudformation create-stack --stack-name $WEBAPP_STACK_NAME --template-url $TEMPLATE --region $REGION --parameters ParameterKey=MieStackName,ParameterValue=$MIE_STACK_NAME ParameterKey=AdminEmail,ParameterValue=$EMAIL --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --profile default --disable-rollback
 ```
 
 #### *Option 2:* Install back-end + front-end
 ```
-TEMPLATE={copy "Without existing MIE deployment" link from output of build script}
+TEMPLATE=[copy "Without existing MIE deployment" link from output of build script]
 aws cloudformation create-stack --stack-name $WEBAPP_STACK_NAME --template-url $TEMPLATE --region $REGION --parameters ParameterKey=AdminEmail,ParameterValue=$EMAIL --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --profile default --disable-rollback
 ```
 

--- a/cloudformation/aws-content-analysis-web.yaml
+++ b/cloudformation/aws-content-analysis-web.yaml
@@ -27,18 +27,60 @@ Mappings:
 
 Resources:
   # Web application resources
+  # WebsiteBucketNameFunction - derive a name for the website bucket based on the lower case stack name.
+  WebsiteBucketNameFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          import string
+          import random
+          import cfnresponse
+          def handler(event, context):
+              stack_name = event['StackId'].split('/')[1].split('-Uuid')[0]
+              response_data = {'Data': stack_name.lower() + '-website'}
+              cfnresponse.send(event, context, cfnresponse.SUCCESS, response_data, "CustomResourcePhysicalID")
+      Handler: index.handler
+      Runtime: python3.8
+      Role: !GetAtt WebsiteBucketNameExecutionRole.Arn
+  WebsiteBucketNameFunctionPermissions:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt WebsiteBucketNameFunction.Arn
+      Principal: 'cloudformation.amazonaws.com'
+  WebsiteBucketNameExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: ['logs:*']
+                Resource: 'arn:aws:logs:*:*:*'
+  GetWebsiteBucketName:
+    Type: Custom::CustomResource
+    Properties:
+      ServiceToken: !GetAtt WebsiteBucketNameFunction.Arn
 
   ContentAnalysisWebsiteBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
       AccessControl: LogDeliveryWrite
-      BucketName:
-        Fn::Transform:
-          Name: 'String'
-          Parameters:
-            InputString: !Sub "${AWS::StackName}-website"
-            Operation: Lower
+      BucketName: !GetAtt GetWebsiteBucketName.Data
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -47,12 +89,7 @@ Resources:
         IndexDocument: "index.html"
         ErrorDocument: "index.html"
       LoggingConfiguration:
-        DestinationBucketName:
-          Fn::Transform:
-            Name: 'String'
-            Parameters:
-              InputString: !Sub "${AWS::StackName}-website"
-              Operation: Lower
+        DestinationBucketName: !GetAtt GetWebsiteBucketName.Data
         LogFilePrefix: "access_logs/"
       LifecycleConfiguration:
         Rules:

--- a/cloudformation/aws-content-analysis.yaml
+++ b/cloudformation/aws-content-analysis.yaml
@@ -93,7 +93,6 @@ Resources:
 
   ContentAnalysisWebStack:
     Type: "AWS::CloudFormation::Stack"
-    DependsOn: StringFunctions
     Properties:
       TemplateURL: !Join
         - ""
@@ -153,7 +152,7 @@ Resources:
           Fn::ImportValue:
             !Sub "${MieStackName}:OperatorLibraryStack"
 
-  # Deploy image workflow 
+  # Deploy image workflow
 
   CompleteImageWorkflow:
     Type: "AWS::CloudFormation::Stack"
@@ -180,27 +179,6 @@ Resources:
         OperatorLibraryStack:
           Fn::ImportValue:
             !Sub "${MieStackName}:OperatorLibraryStack"
-
-  # Custom resources
-
-  StringFunctions:
-    Type: "AWS::CloudFormation::Stack"
-    Properties:
-      TemplateURL: !Join
-        - ""
-        - - "https://"
-          - !FindInMap
-            - ContentAnalysisApp
-            - SourceCode
-            - S3Bucket
-          - .s3.
-          - !Ref AWS::Region
-          - ".amazonaws.com/"
-          - !FindInMap
-            - ContentAnalysisApp
-            - SourceCode
-            - TemplateKeyPrefix
-          - "/string.template"
 
 Outputs:
   ContentAnalyisSolution:

--- a/vue.config.js
+++ b/vue.config.js
@@ -8,7 +8,7 @@ module.exports = {
     plugins: [
       new SriPlugin({
         hashFuncNames: ['sha256', 'sha384'],
-        enabled: false
+        enabled: true
       }),
     ],
     performance: {


### PR DESCRIPTION
*Issue #, if available:*

#21 

*Description of changes:*

In order to support multiple front-end+back-end stacks to be deployed in the same region, I just had to replace the Cloud Formation macro I used for a lower-case string utility function with a custom resource, instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
